### PR TITLE
fix: #10 マインクラフトサーバーのipアドレスがipv6になる

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -41,5 +41,5 @@ class UtilsService:
         """
         このサーバーのIPアドレスを取得します。
         """
-        res = requests.get("https://ifconfig.me")
+        res = requests.get("https://checkip.amazonaws.com/")
         return res.text


### PR DESCRIPTION
- ip照会サイトを使用した時、必ずipv4で取得出来るようにしました。